### PR TITLE
set jekyll action to master to avoid JEKYLL_PAT error

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,6 +16,6 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
           restore-keys: |
             ${{ runner.os }}-gems-
-      - uses: helaili/jekyll-action@2.0.5    # Choose any one of the Jekyll Actions
+      - uses: helaili/jekyll-action@master   # Choose any one of the Jekyll Actions
         with:                                # Some relative inputs of your action
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should solve - https://github.com/Sparrow0hawk/git-calendar-test/actions/runs/4971331310/jobs/8895779856 and follows advice described here - https://github.com/helaili/jekyll-action#use-the-action