### PR TITLE
manually point at main.ics

### DIFF
--- a/_includes/calendars.html
+++ b/_includes/calendars.html
@@ -7,8 +7,7 @@
 <ul>
   <li>
 
-    <a href="{{site.baseurl}}/assets/calendars/example.ics">RSE events</a>
-    (view in <a href="{{site.baseurl}}/assets/calendars/example.ics.Europe-Helsinki.txt">Europe/Helsinki</a>, <a href="{{site.baseurl}}/assets/calendars/example.ics.Europe-Stockholm.txt">Europe/Stockholm</a>)
+    <a href="{{site.baseurl}}/assets/calendars/main.ics">RSE events</a>
     
   </li>
 </ul>


### PR DESCRIPTION
The previous PR #11 missed changing the calendar.html include to point at main.ics rather than example.

This is fixed here but probably highlights some logic that could be improved.