### PR TITLE
add a page on how to subscribe to .ics files

### DIFF
--- a/subscribe.md
+++ b/subscribe.md
@@ -1,0 +1,25 @@
+---
+layout: page
+title: How to subscribe
+permalink: /subscribe/
+---
+
+{% include calendars.html %}
+
+You can subscribe to these calendars in your calendar program.  This
+will periodically import the events by polling the URL, so that you
+get updates (usually with a few hours of delay).  Most programs
+implement this as creating a new calendar which can be toggled on or
+off.  Right click on the link above, "Copy link", and then...
+
+- Google calendar: Other calendars (left sidebar) → "+" to add new →
+  From URL.
+- Outlook web: Add Calendar → Subscribe from web.
+- Thunderbird: Left sidebar → Calendar → "+" to add new → On the
+  network → This location doesn't require credentials → paste URL →
+  ... . Please set to update infrequently.
+- Zimbra: "Add new calendar" → "Add external calendar
+  (other)", "iCAL Subscription" → Paste URL → ... .
+
+Credit: These instructions are reused from Code Refinery's
+  [git-calendar-template](https://github.com/coderefinery/git-calendar-template)


### PR DESCRIPTION
This is lifted directly from the html generated by `git-calendar`, which we credit here explicitly.

It isn't super neat how the include works but i'm OK with this as a first cut.