### PR TITLE
Add handling for event_url field

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ event to the events section with the following YAML format:
     # duration should contain a unit of time: minute, day, hour 
     # and an numeric value
     duration: { minutes: 45 }
+    event_url: www.example.com
 ```
 
 We'll do our best to get to your pull request and merge it so your event is

--- a/_data/main.yaml
+++ b/_data/main.yaml
@@ -11,6 +11,7 @@ events:
   #   location: A venue
   #   begin: YYYY-mm-DD HH:MM:SS
   #   duration: { minutes: 45 }
+  #   event_url: some_url
 
   - summary: PyData London
     #id: test1

--- a/_data/main.yaml
+++ b/_data/main.yaml
@@ -19,11 +19,11 @@ events:
       keynotes on 4 June 2023. It will be on the topic of RSEs and similar
       roles, exploring the similarities and differences between these and
       equivalent non-R(esearch) roles and how people can make the transition
-      from non-R roles to RSE roles and similar. 
-      https://london2023.pydata.org/cfp/talk/EML3U9/
+      from non-R roles to RSE roles and similar.
     location: Warwick
     begin: 2023-06-04 09:00:00
     duration: { minutes: 45 }
+    event_url: https://london2023.pydata.org/cfp/talk/EML3U9/
 
   - summary: Surveying AI Safety Research Directions
     #id: test1
@@ -45,6 +45,7 @@ events:
     location: Zoom
     begin: 2023-06-02 18:00:00
     duration: { minutes: 60 }
+    event_url: https://www.eventbrite.com/e/638192339467?aff=ai
 
   - summary: "AI Beyond STEM: digital skills to unleash the power of data science and AI for all"
     #id: test1
@@ -70,6 +71,7 @@ events:
     location: Zoom
     begin: 2023-06-06 18:00:00
     duration: { minutes: 60 }
+    event_url: https://livingwithmachines.ac.uk/event/ai-beyond-stem-digital-skills-to-unleash-the-power-of-data-science-and-ai-for-all/
 
   - summary: Byte-sized RSE session 8 - README files
     #id: test1
@@ -84,6 +86,7 @@ events:
     location: Zoom
     begin: 2023-06-06 13:00:00
     duration: { minutes: 60 }
+    event_url: https://docs.google.com/forms/d/e/1FAIpQLScYbd6vIrL-Irm_DROs74OTEUkT_84PEv12s7UhiBjfuGhGbA/viewform
 
   - summary: SSI Research Software Camp
     #id: test1
@@ -97,6 +100,7 @@ events:
     location: Zoom
     begin: 2023-06-19 09:00:00
     duration: { days: 11 }
+    event_url: https://www.software.ac.uk/events/2023-01-26-research-software-camp
 
   - summary: RSECon23
     #id: test1
@@ -118,3 +122,4 @@ events:
     location: Swansea University (Remote available)
     begin: 2023-09-05 09:00:00
     duration: { days: 2 }
+    event_url: https://rsecon23.society-rse.org/

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -34,9 +34,17 @@ pagination:
           <li>
             <span class="post-meta">{{ event.date | date: date_format }}</span>
             
+            {%- if event.event_url -%}
+            <h3>
+              <a class="post-link" href="{{ event.event_url | absolute_url }}">
+                {{ event.summary | escape }}
+              </a>
+            </h3>
+            {%- else -%}
             <h3>
                   {{ event.summary | escape }}
             </h3>
+            {% endif %}
               {{ event.description | newline_to_br }}
             <ul>
                 <li>

--- a/_posts/.gitignore
+++ b/_posts/.gitignore
@@ -1,0 +1,3 @@
+*
+!.markdown
+!.gitignore

--- a/_scripts/post_template.md.j2
+++ b/_scripts/post_template.md.j2
@@ -10,6 +10,7 @@ description: |
 location: "{{ location }}"
 date: {{ begin }}
 duration: {{ duration }}
+event_url: {{ event_url }}
 ---
 
 {{ description }} 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-https://github.com/coderefinery/git-calendar/archive/main.zip
+https://github.com/Sparrow0hawk/git-calendar/archive/main.zip
 https://github.com/ics-py/ics-py/archive/refs/heads/main.zip
 jinja2
 pyyaml


### PR DESCRIPTION
This PR adds support for an `event_url` field within the events yaml file. This is used to add a link to the event title on the home page but is not pulled through into the .ics files that our built.

To support this change this PR migrates a dependency to a fork of the git-calendar project where i've added logic for handling none event fields https://github.com/Sparrow0hawk/git-calendar/pull/1