### PR TITLE
add a test build github action

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,41 @@
+name: Test build the site
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Info
+        run: |
+          echo ${{ github.ref }}
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: build calendar files
+        run: |
+          ./build.sh --edit-link=https://github.com/$GITHUB_REPOSITORY
+          mv ./out/* assets/calendars/
+      - name: create posts
+        run: |
+          python _scripts/generate_posts.py
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - uses: helaili/jekyll-action@master   # Choose any one of the Jekyll Actions
+        with:                                # Some relative inputs of your action
+          token: ${{ secrets.GITHUB_TOKEN }}
+          build_only: true
+          
+        


### PR DESCRIPTION
This PR adds a github action that runs the website build pipeline but doesn't deploy it. This runs as a validation step on pull requests to main to check that the site should build and catch any issues.