### PR TITLE
Add logic for showing multiple cals

### DIFF
--- a/_includes/calendars.html
+++ b/_includes/calendars.html
@@ -1,13 +1,24 @@
 <h2>Subscribe to these calendars</h2>
 
 <p>
-    Use the links below to subscribe to this calendar using .ics files.
+  Use the links below to subscribe to this calendar using .ics files.
 </p>
 
 <ul>
   <li>
-
     <a href="{{site.baseurl}}/assets/calendars/main.ics">RSE events</a>
-    
   </li>
+
+  {% for file in site.static_files %}
+  {% if file.path contains 'calendars/' %}
+  {% assign name_size = file.name | split: "." | size %}
+  {% if name_size >= 3 %}
+  <li>
+
+    <a href="{{site.baseurl}}/assets/{{ file.path }}">RSE events - {{ file.name | split: "." | slice: 1}}</a>
+
+  </li>
+  {% endif %}
+  {% endif %}
+  {% endfor %}
 </ul>

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,3 @@
 git-calendar _data/main.yaml -o out -i out/index.html \
-    --timezone=Europe/London \
-    --timezone=Europe/Berlin \ 
+    --timezone=Europe/London,Europe/Berlin \
     "$@"

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
-git-calendar _data/*.yaml -o out -i out/index.html \
+git-calendar _data/main.yaml -o out -i out/index.html \
     --timezone=Europe/London \
+    --timezone=Europe/Berlin
     "$@"

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 git-calendar _data/main.yaml -o out -i out/index.html \
     --timezone=Europe/London \
-    --timezone=Europe/Berlin
+    --timezone=Europe/Berlin \ 
     "$@"

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 git-calendar _data/main.yaml -o out -i out/index.html \
-    --timezone=Europe/London,Europe/Berlin \
+    --timezone=Europe/London --timezone=Europe/Berlin \
     "$@"


### PR DESCRIPTION
This PR aims to:

1. Introduce building .ics files for Europe/Berlin CET
2. Introduce logic for populating available .ics files based on those in `assets/calendars` solving #16 

This goes some way to trying to address points in #34 