### PR TITLE
only move .ics files to assets/calendars

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,7 +25,7 @@ jobs:
       - name: build calendar files
         run: |
           ./build.sh --edit-link=https://github.com/$GITHUB_REPOSITORY
-          mv ./out/* assets/calendars/
+          mv ./out/*.ics assets/calendars/
       - name: create posts
         run: |
           python _scripts/generate_posts.py

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: build calendar files
         run: |
           ./build.sh --edit-link=https://github.com/$GITHUB_REPOSITORY
-          mv ./out/* assets/calendars/
+          mv ./out/*.ics assets/calendars/
       - name: create posts
         run: |
           python _scripts/generate_posts.py


### PR DESCRIPTION
Minor change to fix #39 that only brings in the generated .ics files from the git-calendar step.