### PR TITLE
add europe/london to home page layout

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -32,7 +32,7 @@ pagination:
         {% if postStartDate >= curDate %}
 
           <li>
-            <span class="post-meta">{{ event.date | date: date_format }}</span>
+            <span class="post-meta">{{ event.date | date: date_format }} Europe/London</span>
             
             {%- if event.event_url -%}
             <h3>


### PR DESCRIPTION
Part of addressing https://github.com/Sparrow0hawk/rse-calendar/issues/34 is making the timezone of events listed clearer. This small change should hopefully go some way to improving this.