### PR TITLE
if someone includes a link in location it should be clickable

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -48,7 +48,7 @@ pagination:
               {{ event.description | markdownify }}
             <ul>
                 <li>
-                    <strong>Location:</strong> {{ event.location | escape }}
+                    <strong>Location:</strong> {{ event.location | markdownify }}
                 </li>
                 <li>
                     <strong>Duration:</strong> {% include duration.html duration = event.duration %}


### PR DESCRIPTION
Switch to `markdownify` filter for locations for instances where a URL is included.