### PR TITLE
add handling for duration hours

### DIFF
--- a/_includes/duration.html
+++ b/_includes/duration.html
@@ -10,9 +10,12 @@
     {% if duration.minutes < 60 %}
 
         {{ duration.minutes }} minutes
-
     {% else %}
         1 hour
     {% endif %}
+
+{% elsif duration.hours %}
+
+    {{duration.hours}} hours
 
 {% endif %}


### PR DESCRIPTION
I haven't added template handling for `duration.hours` in the duration includes so adding that here.