### PR TITLE
Fix codeless contribute model

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-an-event-template.md
+++ b/.github/ISSUE_TEMPLATE/add-an-event-template.md
@@ -12,14 +12,14 @@ assignees: ''
 I want to add the following event to the RSE calendar:
 
 ```yaml
-  - summary: event title
-    description: |
-      A description of your event
-      over multiple
-       lines.
-       With URLs wrapped in <www.example.com>
-    location: A venue
-    begin: YYYY-mm-DD HH:MM:SS
-    duration: { minutes: 45 }
-    event_url: some_url
+summary: event title
+description: |
+    A description of your event
+    over multiple
+    lines.
+    With URLs wrapped in <www.example.com>
+location: A venue
+begin: YYYY-mm-DD HH:MM:SS
+duration: { minutes: 45 }
+event_url: some_url
 ```

--- a/.github/workflows/issue_to_pull.yml
+++ b/.github/workflows/issue_to_pull.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+            ssh-key: ${{ secrets.DEPLOY_KEY }}
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ contributed to easily.
 
 ## Contributing an event to the calendar
 
+There are 2 main ways to contribute an event to the calendar.
+
+### Submit using GitHub Issues
+
+You can use the [Add event GitHub Issue
+template](https://github.com/Sparrow0hawk/rse-calendar/issues/new?assignees=&labels=add-event&projects=&template=add-an-event-template.md&title=%5BEVENT+TITLE%5D)
+to submit an issue where you complete the yaml block with details of your event
+to trigger a GitHub action workflow that automatically submits a pull request
+with your event details to the project. Allowing you to contribute an event
+without touching any code!
+
+This pull request will need to be approved before your event appears on the website.
+
+### Submit as a Pull Request
+
 To add an event to the calendar you should suggest a [pull
 request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request?tool=webui)
 to the repository that updated the [main data file](./_data/main.yaml) to add a new


### PR DESCRIPTION
This PR:

- removes YAML node to prevent duplicate node addition
- Adds deploy keys to allow automated PRs to run other actions (https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs)