### PR TITLE
Adding support for ongoing events

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -28,25 +28,6 @@ pagination:
       {%- assign date_format = site.minima.date_format | default: "%d %B %Y %I:%M:%S %p"  -%}
       {%- for event in events -%}
 
-      {% if event.duration.day %} 
-
-      {% assign postDuration = event.duration.day | times: 86400 %}
-
-      {% elsif event.duration.hours %} 
-
-      {% assign postDuration = event.duration.hours | times: 3600 %}
-
-      {% else %} 
-
-      {% assign postDuration = event.duration.minutes | times: 60 %}
-
-      {% endif %}
-
-      {% assign postStartDate = event.date | date: '%s' %}
-
-      {% assign postEndDate = postStartDate | plus: postDuration %}
-        {% if postEndDate >= curDate %}
-
           <li>
             <span class="post-meta">{{ event.date | date: date_format }} Europe/London</span>
             
@@ -72,7 +53,6 @@ pagination:
             </ul>
 
           </li>
-        {%- endif -%}
       {%- endfor -%}
     </ul>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -28,8 +28,24 @@ pagination:
       {%- assign date_format = site.minima.date_format | default: "%d %B %Y %I:%M:%S %p"  -%}
       {%- for event in events -%}
 
+      {% if event.duration.day %} 
+
+      {% assign postDuration = event.duration.day | times: 86400 %}
+
+      {% elsif event.duration.hours %} 
+
+      {% assign postDuration = event.duration.hours | times: 3600 %}
+
+      {% else %} 
+
+      {% assign postDuration = event.duration.minutes | times: 60 %}
+
+      {% endif %}
+
       {% assign postStartDate = event.date | date: '%s' %}
-        {% if postStartDate >= curDate %}
+
+      {% assign postEndDate = postStartDate | plus: postDuration %}
+        {% if postEndDate >= curDate %}
 
           <li>
             <span class="post-meta">{{ event.date | date: date_format }} Europe/London</span>

--- a/_scripts/generate_posts/generate_posts.py
+++ b/_scripts/generate_posts/generate_posts.py
@@ -29,7 +29,11 @@ def main(override=False):
     today = datetime.datetime.today()
 
     for event in data:
-        if event["begin"] >= today:
+
+        # calculate a post end date 
+        postEndDate = event["begin"] + datetime.timedelta(**event["duration"])
+
+        if postEndDate >= today:
             filename = (
                 str(event["begin"].strftime("%Y-%m-%d"))
                 + "-"


### PR DESCRIPTION
This PR changes the logic for "popping" events off the calendar.

At present events don't appear on the calendar when start time of the event is after the execution time of `generate_posts.py`. This is fine for short events but if your event runs over multiple days it means your event disappears after the start time has passed. This isn't very helpful for showcasing ongoing events.

This PR also:

- tidies up code in the `_layouts/home.html` template, removing duplication of logic for showing only future events. Since this is handled in our post generation logic it feels right to just remove this.
- Adds logic for calculating event end time and uses that are the key determinant of if a post is generated.